### PR TITLE
Remove udev rules note from AppStream description

### DIFF
--- a/patches/gqrx-metainfo.patch
+++ b/patches/gqrx-metainfo.patch
@@ -1,5 +1,5 @@
 diff --git a/dk.gqrx.gqrx.appdata.xml b/dk.gqrx.gqrx.appdata.xml
-index 2b23158..0d45eec 100644
+index 2b23158..e5a8625 100644
 --- a/dk.gqrx.gqrx.appdata.xml
 +++ b/dk.gqrx.gqrx.appdata.xml
 @@ -1,5 +1,5 @@
@@ -9,19 +9,7 @@ index 2b23158..0d45eec 100644
    <id>dk.gqrx.gqrx</id>
    <name>Gqrx</name>
    <summary>Software defined radio receiver implemented using GNU Radio and the Qt GUI toolkit</summary>
-@@ -16,6 +16,11 @@
-    <p>
-     Gqrx supports many of the SDR hardware available, including Airspy, Funcube Dongles, rtl-sdr, HackRF and USRP devices.
-    </p>
-+   <p>
-+    Please note that the Gqrx Flatpak requires udev rules for most SDR devices to be installed. Many of these should already
-+    be part of your system, but if your SDR device does not work, you will have to install the tools for your SDR via regular
-+    package manager followed by system reboot before using Gqrx.
-+   </p>
-   </description>
-   <metadata_license>CC-BY-3.0</metadata_license>
-   <project_license>GPL-3.0</project_license>
-@@ -28,10 +33,13 @@
+@@ -28,10 +28,13 @@
    <launchable type="desktop-id">dk.gqrx.gqrx.desktop</launchable>
    <screenshots>
      <screenshot type="default">


### PR DESCRIPTION
Almost all the SDR udev rules were already upstreamed months ago and it is now only a matter of time before they are available in most distributions, so this (possibly confusing) note should no longer be needed.