### PR TITLE
Update rtlsdr

### DIFF
--- a/dk.gqrx.gqrx.yaml
+++ b/dk.gqrx.gqrx.yaml
@@ -118,8 +118,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/steve-m/librtlsdr.git
-        tag: v2.0.2
-        commit: 619ac3186ea0ffc092615e1f59f7397e5e6f668c
+        # latest master for 2.0.2 versioning fix
+        commit: ae0dd6d4f09088d13500a854091b45ad281ca4f0
 
   - name: volk
     buildsystem: cmake-ninja


### PR DESCRIPTION
Latest master for 2.0.2 versioning fix.