### PR TITLE
Bump rtlsdr to 2.0.3

### DIFF
--- a/dk.gqrx.gqrx.yaml
+++ b/dk.gqrx.gqrx.yaml
@@ -145,8 +145,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/steve-m/librtlsdr.git
-        # latest master for 2.0.2 versioning fix
-        commit: ae0dd6d4f09088d13500a854091b45ad281ca4f0
+        tag: v2.0.3
+        commit: 797f8143266d983c56d8f35d2d442527529dd8a5
 
   - name: volk
     buildsystem: cmake-ninja


### PR DESCRIPTION
Bumps librtlsdr to 2.0.3 which adds support for RTL-SDR Blog V4L and some other minor changes

https://github.com/steve-m/librtlsdr/blob/797f8143266d983c56d8f35d2d442527529dd8a5/debian/changelog#L1