### PR TITLE
Update rtlsdr

### DIFF
--- a/dk.gqrx.gqrx.yaml
+++ b/dk.gqrx.gqrx.yaml
@@ -145,8 +145,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/steve-m/librtlsdr.git
-        # latest master for 2.0.2 versioning fix
-        commit: ae0dd6d4f09088d13500a854091b45ad281ca4f0
+        commit: 797f8143266d983c56d8f35d2d442527529dd8a5
 
   - name: volk
     buildsystem: cmake-ninja


### PR DESCRIPTION
Latest 2.0.3 release for RTL-SDR Blog V4L support and other improvements.